### PR TITLE
Neut 111 tempest fix

### DIFF
--- a/networking_kaloom/ml2/drivers/kaloom/common/utils.py
+++ b/networking_kaloom/ml2/drivers/kaloom/common/utils.py
@@ -18,6 +18,7 @@ from oslo_db import exception as db_exc
 from eventlet import greenthread
 from oslo_log import log
 from xml.sax.saxutils import escape
+import netaddr
 
 LOG = log.getLogger(__name__)
 
@@ -91,3 +92,10 @@ def tp_operation_unlock(host, network_id):
     kaloom_db.delete_tp_operation(host, network_id)
     LOG.debug('tp_operation_unlock for host=%s, network_id=%s', host, network_id)
 
+def get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs):
+    given_net = netaddr.IPNetwork(given_ip_cidr)
+    for ip_cidr in existing_ip_cidrs:
+        existing_net = netaddr.IPNetwork(ip_cidr)
+        if given_net in existing_net or existing_net in given_net:
+            return ip_cidr
+    return None

--- a/networking_kaloom/ml2/drivers/kaloom/common/utils.py
+++ b/networking_kaloom/ml2/drivers/kaloom/common/utils.py
@@ -94,11 +94,12 @@ def tp_operation_unlock(host, network_id):
 
 def get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs):
     given_net = netaddr.IPNetwork(given_ip_cidr)
+    overlapped_ip_cidrs=[]
     for ip_cidr in existing_ip_cidrs:
         existing_net = netaddr.IPNetwork(ip_cidr)
         if given_net in existing_net or existing_net in given_net:
-            return ip_cidr
-    return None
+            overlapped_ip_cidrs.append(ip_cidr)
+    return overlapped_ip_cidrs
 
 #command pattern for reversible operations
 # receiver

--- a/networking_kaloom/ml2/drivers/kaloom/common/utils.py
+++ b/networking_kaloom/ml2/drivers/kaloom/common/utils.py
@@ -99,3 +99,46 @@ def get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs):
         if given_net in existing_net or existing_net in given_net:
             return ip_cidr
     return None
+
+#command pattern for reversible operations
+# receiver
+class vfabric_operation_reversible:
+    def __init__(self, vfabric, do_operation, undo_operation):
+        self.vfabric = vfabric
+        self.do_operation = do_operation
+        self.undo_operation = undo_operation
+
+    def execute(self, *args, **kwargs):
+        method = getattr(self.vfabric, self.do_operation)
+        return method(*args, **kwargs)
+
+    def undo(self, *args, **kwargs):
+        method = getattr(self.vfabric, self.undo_operation)
+        return method(*args, **kwargs)
+
+# command
+class Command:
+    def __init__(self, receiver, *args, **kwargs):
+        self.receiver = receiver
+        self.args = args
+        self.kwargs = kwargs
+    def execute(self):
+        return self.receiver.execute(*self.args, **self.kwargs)
+    def undo(self):
+        return self.receiver.undo(*self.args, **self.kwargs)
+
+# invoker
+class Invoker:
+    def __init__(self):
+        self.history = []
+    def execute(self, command):
+        resp = command.execute()
+        self.history.append(command)
+        return resp
+    def undo(self):
+        while len(self.history) > 0:
+           command = self.history.pop()
+           try:
+              command.undo()
+           except:
+              pass

--- a/networking_kaloom/services/l3/driver.py
+++ b/networking_kaloom/services/l3/driver.py
@@ -173,6 +173,11 @@ class KaloomL3Driver(object):
                     msg = "non-existing vfabric router"
                     raise ValueError(msg)
 
+                #plugin.remove_router_interface left stale data on vfabric? not cleaned yet? then reuse.
+                #avoids "add_ipaddress_to_interface failed: That ipv4 address already exist for that router"
+                if router_info['ip_address'] in router_inf_info['ip_addresses']:
+                    return
+
                 ## first subnet request ? absence of router--l2_node interface, first create interface.
                 attach_router_called = False
                 if tp_interface_name is None:

--- a/networking_kaloom/services/l3/driver.py
+++ b/networking_kaloom/services/l3/driver.py
@@ -155,19 +155,23 @@ class KaloomL3Driver(object):
                 LOG.error(msg)
                 raise kaloom_exc.KaloomServicePluginRpcError(msg=msg)
 
+    def _delete_stale_ipaddress_from_interface(self, interface_info, given_ip_cidr, existing_ip_cidrs):
+        overlapped_subnet_ip_cidr = utils.get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs )
+        if overlapped_subnet_ip_cidr is not None:
+            if given_ip_cidr == overlapped_subnet_ip_cidr:
+                #already exists exact ip/subnet in vfabric, don't delete, reuse
+                return False
+            else:
+                #clean overlap now: by calling delete_ipaddress_to_interface
+                interface_info['ip_address'] = overlapped_subnet_ip_cidr.split('/')[0]
+                self.vfabric.delete_ipaddress_from_interface(interface_info)
+        return True
+
     def add_router_interface(self, context, router_info):
         """In case of no router interface present for the network of subnet, creates the interface.
         Adds a subnet configuration to the router interface on Kaloom vFabric.
         This deals with both IPv6 and IPv4 configurations. 
         """
-        def _get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs ):
-            given_net = netaddr.IPNetwork(given_ip_cidr)
-            for ip_cidr in existing_ip_cidrs:
-                existing_net = netaddr.IPNetwork(ip_cidr)
-                if given_net in existing_net or existing_net in given_net:
-                    return ip_cidr
-            return None
-
         if router_info:
             router_name = utils._kaloom_router_name(self.prefix, router_info['id'],
                                                    router_info['name'])
@@ -194,18 +198,13 @@ class KaloomL3Driver(object):
                 interface_info['ip_version'] = router_info['ip_version']
                 prefix_length = router_info['cidr'].split('/')[1]
 
-                #plugin.remove_router_interface left stale data on vfabric? not cleaned yet? then reuse or update.
+                #plugin.remove_router_interface left stale data on vfabric? not cleaned yet? then delete (first) or reuse.
                 #otherwise multiple IPs of same subnet would complain "That ipv4 address already exist for that router"
                 given_ip_cidr = '%s/%s' % (router_info['ip_address'], prefix_length)
-                overlapped_subnet_ip_cidr = _get_overlapped_subnet(given_ip_cidr, router_inf_info['cidrs'] )
-                if overlapped_subnet_ip_cidr is not None:
-                    if given_ip_cidr == overlapped_subnet_ip_cidr:
-                        #already exists exact ip/subnet in vfabric, nothing to do.
-                        return
-                    else:
-                        #clean overlap now: by calling delete_ipaddress_to_interface
-                        interface_info['ip_address'] = overlapped_subnet_ip_cidr.split('/')[0]
-                        self.vfabric.delete_ipaddress_from_interface(interface_info)
+                deleted = self._delete_stale_ipaddress_from_interface(interface_info, given_ip_cidr, router_inf_info['cidrs'])
+                if not deleted:
+                    #already exists exact ip/subnet in vfabric, which is not deleted to reuse.
+                    return
 
                 #add_ipaddress_to_interface
                 interface_info['ip_address'] = router_info['ip_address']

--- a/networking_kaloom/services/l3/driver.py
+++ b/networking_kaloom/services/l3/driver.py
@@ -156,7 +156,8 @@ class KaloomL3Driver(object):
                 raise kaloom_exc.KaloomServicePluginRpcError(msg=msg)
 
     def _delete_stale_ipaddress_from_interface(self, interface_info, given_ip_cidr, existing_ip_cidrs):
-        overlapped_subnet_ip_cidr = utils.get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs )
+        overlapped_subnet_ip_cidrs = utils.get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs )
+        overlapped_subnet_ip_cidr = overlapped_subnet_ip_cidrs[0] if len(overlapped_subnet_ip_cidrs) > 0 else None
         if overlapped_subnet_ip_cidr is not None:
             if given_ip_cidr == overlapped_subnet_ip_cidr:
                 #already exists exact ip/subnet in vfabric, don't delete, reuse

--- a/networking_kaloom/services/l3/driver.py
+++ b/networking_kaloom/services/l3/driver.py
@@ -178,7 +178,7 @@ class KaloomL3Driver(object):
                                                    router_info['name'])
             l2_node_id = router_info['nw_name']
             try:
-                invoker = utils.Invoker()
+                attachFabricOperation = utils.Invoker()
                 LOG.info('Trying to add subnet %s to vfabric router %s -- network %s', router_info['subnet_id'], router_name, l2_node_id)
                 router_inf_info = self.vfabric.get_router_interface_info(router_name, l2_node_id)
                 vfabric_router_id = router_inf_info['node_id']
@@ -190,7 +190,7 @@ class KaloomL3Driver(object):
                 ## first subnet request ? absence of router--l2_node interface, first create interface.
                 if tp_interface_name is None:
                     command = utils.Command(utils.vfabric_operation_reversible(self.vfabric, 'attach_router', 'detach_router'), vfabric_router_id, l2_node_id)
-                    tp_interface_name = invoker.execute(command)
+                    tp_interface_name = attachFabricOperation.execute(command)
 
                 #interface_info common to both add and delete.
                 interface_info={}
@@ -219,7 +219,7 @@ class KaloomL3Driver(object):
                 msg = (_('Failed to add subnet %s (IP %s) to vfabric router '
                     '%s -- network %s, err:%s') % (router_info['subnet_id'], router_info['ip_address'], router_name, l2_node_id, e))
                 LOG.error(msg)
-                invoker.undo()
+                attachFabricOperation.undo()
                 raise kaloom_exc.KaloomServicePluginRpcError(msg=msg)
 
     def remove_router_interface(self, context, router_info):

--- a/networking_kaloom/services/l3/plugin.py
+++ b/networking_kaloom/services/l3/plugin.py
@@ -542,5 +542,5 @@ class KaloomL3ServicePlugin(service_base.ServicePluginBase,
                 self.driver.remove_router_interface(context, router_info)
                 return router_ifc_to_del
             except Exception as e:
-                msg = "remove_router_interface failed in vfabric: %s" % (e)
+                msg = "remove_router_interface (router %s -- IP %s subnet_id %s) failed in vfabric: %s" % (router['name'], ip_address, subnet['id'], e)
                 LOG.error(msg)

--- a/networking_kaloom/services/l3/plugin.py
+++ b/networking_kaloom/services/l3/plugin.py
@@ -161,12 +161,12 @@ class KaloomL3SyncWorker(worker.BaseWorker):
             # Sync (vfabric.add_router_interface) can't go in parallel with router operations (on same router)
             # to avoid race condition of creating router--network link.
             # parallelism of router operations (on different router)
-            # read (s) lock on "the router" during transaction.
+            # write (x) lock on "the router" during transaction (supports multiple sync_router_interfaces operations)
             db_session = db_api.get_writer_session()
             with db_session.begin(subtransactions=True):
                 try:
                     caller_msg = 'l3_sync_interface on router id=%s name=%s' % (r['id'] , r['name'])
-                    kaloom_db.get_Lock(db_session, r['id'], read=True, caller_msg = caller_msg)
+                    kaloom_db.get_Lock(db_session, r['id'], read=False, caller_msg = caller_msg)
                 except Exception as e:
                     #no record (router deleted): nothing to sync for the router
                     #lock timeout 

--- a/networking_kaloom/tests/unit/ml2/drivers/kaloom/common/test_utils.py
+++ b/networking_kaloom/tests/unit/ml2/drivers/kaloom/common/test_utils.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Kaloom, Inc.  All rights reserved.
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.tests import base
+from networking_kaloom.ml2.drivers.kaloom.common import utils
+
+class UtilsTestCase(base.BaseTestCase):
+    def setUp(self):
+        super(UtilsTestCase, self).setUp()
+
+    def tearDown(self):
+        super(UtilsTestCase, self).tearDown()
+
+    def test_get_overlapped_subnet(self):
+        given_ip_cidr = '192.168.0.1/24'
+        existing_ip_cidrs = ['192.168.0.1/24', '192.168.0.2/24', '192.168.0.2/30', '192.168.1.1/22', '192.168.1.1/24']
+        expected_overlapped = ['192.168.0.1/24', '192.168.0.2/24', '192.168.0.2/30', '192.168.1.1/22']
+        overlapped_subnet_ip_cidrs = utils.get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs )
+        self.assertEquals(set(overlapped_subnet_ip_cidrs), set(expected_overlapped),
+                          "result should be {}, got {}".format(expected_overlapped, overlapped_subnet_ip_cidrs))
+
+        given_ip_cidr = '192.168.0.1/24'
+        existing_ip_cidrs = ['192.168.1.1/24']
+        expected_overlapped = []
+        overlapped_subnet_ip_cidrs = utils.get_overlapped_subnet(given_ip_cidr, existing_ip_cidrs )
+        self.assertEquals(set(overlapped_subnet_ip_cidrs), set(expected_overlapped),
+                          "result should be {}, got {}".format(expected_overlapped, overlapped_subnet_ip_cidrs))

--- a/networking_kaloom/tests/unit/services/l3/test_driver.py
+++ b/networking_kaloom/tests/unit/services/l3/test_driver.py
@@ -1,0 +1,87 @@
+# Copyright 2019 Kaloom, Inc.  All rights reserved.
+# Copyright (c) 2018 OpenStack Foundation
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from mock import patch, Mock
+from oslo_utils import uuidutils
+from neutron.tests import base
+from neutron_lib import context as neutron_context
+from networking_kaloom.ml2.drivers.kaloom.common import utils
+from networking_kaloom.services.l3 import driver as kaloom_l3_driver
+from networking_kaloom.services.l3.driver import LOG
+
+LOG.error = Mock()
+
+class KaloomL3DriverTestCase(base.BaseTestCase):
+    PREFIX = '__OpenStack__'
+    DB_CONTEXT = neutron_context.get_admin_context()
+    ROUTER_INFO = {'id': uuidutils.generate_uuid(), 
+                'name': 'router1',
+                'nw_name': utils._kaloom_nw_name(PREFIX, uuidutils.generate_uuid()),
+                'subnet_id': uuidutils.generate_uuid(),
+                'ip_address': '192.168.1.15',
+                'cidr':'192.168.1.15/24',
+                'ip_version':'4',
+                'gip': '192.168.1.1'}
+    ROUTER_NODE_ID = uuidutils.generate_uuid()
+    ROUTER_INTERFACE_INFO_FIRST_TIME = {'node_id': ROUTER_NODE_ID, 'interface': None, 'cidrs': []}
+    ROUTER_INTERFACE_INFO_EXACT_STALE = {'node_id': ROUTER_NODE_ID, 'interface': 'net1', 'cidrs': ['192.168.1.15/24']}
+    ROUTER_INTERFACE_INFO_NON_EXACT_OVERLAPPING = {'node_id': ROUTER_NODE_ID, 'interface': 'net1', 'cidrs': ['192.168.1.16/24']}
+
+    @patch('networking_kaloom.services.l3.driver.KaloomNetconf',autospec=True)
+    def setUp(self, mock_KaloomNetconf):
+        super(KaloomL3DriverTestCase, self).setUp()
+        self.driver = kaloom_l3_driver.KaloomL3Driver(self.PREFIX)
+        self.mock_KaloomNetconf_instance = mock_KaloomNetconf.return_value
+
+    def tearDown(self):
+        super(KaloomL3DriverTestCase, self).tearDown()
+        self.mock_KaloomNetconf_instance.reset_mock()
+        LOG.error.reset_mock()
+    
+    def test_add_router_interface_first_time(self):
+        self.mock_KaloomNetconf_instance.get_router_interface_info = Mock(return_value = self.ROUTER_INTERFACE_INFO_FIRST_TIME)
+        self.driver.add_router_interface(self.DB_CONTEXT, self.ROUTER_INFO)
+
+        self.mock_KaloomNetconf_instance.attach_router.assert_called_once()
+        self.mock_KaloomNetconf_instance.delete_ipaddress_from_interface.assert_not_called()
+        self.mock_KaloomNetconf_instance.add_ipaddress_to_interface.assert_called_once()
+        LOG.error.assert_not_called
+ 
+    def test_add_router_interface_exact_stale(self):
+        self.mock_KaloomNetconf_instance.get_router_interface_info = Mock(return_value = self.ROUTER_INTERFACE_INFO_EXACT_STALE)
+        self.driver.add_router_interface(self.DB_CONTEXT, self.ROUTER_INFO)
+
+        self.mock_KaloomNetconf_instance.attach_router.assert_not_called()
+        self.mock_KaloomNetconf_instance.delete_ipaddress_from_interface.assert_not_called()
+        self.mock_KaloomNetconf_instance.add_ipaddress_to_interface.assert_not_called()
+        LOG.error.assert_not_called
+
+    def test_add_router_interface_non_exact_overlapping(self):
+        self.mock_KaloomNetconf_instance.get_router_interface_info = Mock(return_value = self.ROUTER_INTERFACE_INFO_NON_EXACT_OVERLAPPING)
+        self.driver.add_router_interface(self.DB_CONTEXT, self.ROUTER_INFO)
+
+        self.mock_KaloomNetconf_instance.attach_router.assert_not_called()
+        self.mock_KaloomNetconf_instance.delete_ipaddress_from_interface.assert_called_once()
+        self.mock_KaloomNetconf_instance.add_ipaddress_to_interface.assert_called_once()
+        LOG.error.assert_not_called
+
+    def test_add_router_interface_undo_attach_router(self):
+        self.mock_KaloomNetconf_instance.get_router_interface_info = Mock(return_value = self.ROUTER_INTERFACE_INFO_FIRST_TIME)
+        self.mock_KaloomNetconf_instance.add_ipaddress_to_interface = Mock(side_effect = Exception('Boom!'))
+        try:
+           self.driver.add_router_interface(self.DB_CONTEXT, self.ROUTER_INFO)
+        except:
+           pass
+        self.mock_KaloomNetconf_instance.attach_router.assert_called_once()
+        self.mock_KaloomNetconf_instance.detach_router.assert_called_once()


### PR DESCRIPTION
fixes NEUT-111
fix for "add_ipaddress_to_interface failed: That ipv4 address already exist for that router"
use of write lock to avoid race condition in case of multiple sync_router_interfaces operations
more logging for add/remove_router_interface