### PR TITLE
KSDF-12918 ML2 plugin: error not discard when kaloom_kvs and kaloom_o…

### DIFF
--- a/networking_kaloom-setup.cfg
+++ b/networking_kaloom-setup.cfg
@@ -13,7 +13,7 @@
 
 [metadata]
 name = networking_kaloom
-version = 0.1.1
+version = 0.1.2
 summary = Kaloom Networking drivers for Queens OpenStack
 author = Kaloom
 author-email = info@kaloom.com

--- a/networking_kaloom/ml2/drivers/kaloom/common/kaloom_netconf.py
+++ b/networking_kaloom/ml2/drivers/kaloom/common/kaloom_netconf.py
@@ -1026,7 +1026,7 @@ class KaloomNetconf(object):
                 return
         except AttributeError:
             LOG.warning('session-id: %s, msg-reply: %s', self.netconf_session_id, resp)
-            raise ValueError(resp_xml['rpc-error']['error-message'])
+            raise ValueError({'error-tag': resp_xml['rpc-error']['error-tag'], 'error-message': resp_xml['rpc-error']['error-message']})
 
     def list_router_name_id(self):
         req = L3_command_dict["LIST_ROUTER"]

--- a/networking_kaloom/ml2/drivers/kaloom/mech_driver/mech_kaloom.py
+++ b/networking_kaloom/ml2/drivers/kaloom/mech_driver/mech_kaloom.py
@@ -552,7 +552,7 @@ class KaloomOVSMechanismDriver(OpenvswitchMechanismDriver):
             knid = self.vfabric.create_l2_network(nw_name, gui_nw_name, kconst.DEFAULT_VLAN_ID).get('kaloom_knid')
         except Exception as e:
             ##duplicate should not raise error (TYPE_KNID is used by both kaloom_ovs and kaloom_kvs mech driver)
-            if "unique duplicate constraint" in str(e):
+            if eval(str(e))['error-tag'] == 'data-exists':
                return
             else:
                LOG.error("errors: %s", e)


### PR DESCRIPTION
…vs are used together

When both mechanism drives kaloom_ovs and kaloom_kvs are used, both will send requests to the fabric to create a new L2 network. Normally, the second request triggers an error which is silently discarded. The error message has been changed on newer fabric versions.
Going forward (1.10-378 and 1.11-226), we rely on error-tag: data-exists.